### PR TITLE
Indexing bug in `compute_npmi_at_n_during_training`

### DIFF
--- a/compute_npmi.py
+++ b/compute_npmi.py
@@ -101,10 +101,10 @@ def compute_npmi_at_n_during_training(beta, ref_counts, n=10, smoothing=0.01):
         order = np.argsort(beta[k, :])[::-1]
         indices = order[:n]
         npmi_vals = []
-        for index1 in indices:
-            for index2 in indices:
-                col1 = np.array(ref_counts[:, index1] > 0, dtype=int) + smoothing
-                col2 = np.array(ref_counts[:, index2] > 0, dtype=int) + smoothing
+        for i, index1 in enumerate(indices):
+            for index2 in indices[i+1:n]:
+                col1 = np.array((ref_counts[:, index1] > 0).todense(), dtype=int) + smoothing
+                col2 = np.array((ref_counts[:, index2] > 0).todense(), dtype=int) + smoothing
                 c1 = col1.sum()
                 c2 = col2.sum()
                 c12 = np.sum(col1 * col2)


### PR DESCRIPTION
I noticed that you have a minor indexing bug in the within-training NPMI calculation, so I changed it to match how you calculate `compute_npmi_at_n`.

Note that it assumes a sparse input. This is appropriate for my fork, but I couldn't tell at a glance if this was right for yours.